### PR TITLE
fix: event description does not include starting time #86

### DIFF
--- a/frontend/src/views/TheItemView.vue
+++ b/frontend/src/views/TheItemView.vue
@@ -150,14 +150,14 @@
               <em>{{ $t('no-address') }}</em>
             </div>
           </article>
-          <article id="availability" v-if="isOwner || notAvailableYet || item.enddate" class="mb-5-5">
+          <article id="availability" v-if="isOwner || notAvailableYet || item.enddate || item.type === 'EV'" class="mb-5-5">
             <div class="title is-size-4 mb-2">
               <div class="icon-text">
                 <span class="icon is-medium"><i class="fas fa-calendar-day"></i></span>
                 <span>{{ $t('availability') }}</span>
               </div>
             </div>
-            <template v-if="isOwner || itemHasEnded || notAvailableYet">
+            <template v-if="isOwner || itemHasEnded || notAvailableYet || item.type === 'EV'">
               <span>
                 {{ $t('item-availability-from') }}
                 {{ formattedDate(item.startdate, $i18n.locale) }} ({{ formattedDateFromNow(item.startdate, $i18n.locale) }})
@@ -275,7 +275,7 @@ export default {
       return itemCategories;
     },
     notAvailableYet() {
-      return this.item.enddate && new Date(this.item.enddate) <= Date.now();
+      return this.item.startdate && new Date(this.item.startdate) > Date.now();
     },
     itemHasEnded() {
       return this.item.enddate && new Date(this.item.enddate) <= Date.now();


### PR DESCRIPTION
On events, starting time will always be displayed. Also fixed the "notAvailableYet()" function that didn't work, so now if any item hasn't started yet it should also display the future starting time.